### PR TITLE
fix: correct npm package name to chdb-node

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -193,7 +193,7 @@ sudo yum install -y libchdb
 
 #### Installation
 ```bash
-npm install node-chdb
+npm install chdb-node
 ```
 
 #### Usage


### PR DESCRIPTION
Hi, I was looking over the docs and there looks to be a typo for the npm install. This looks to be the correct package https://www.npmjs.com/package/chdb-node